### PR TITLE
Implement a switch to suppress error messages

### DIFF
--- a/include/qd/dd_real.h
+++ b/include/qd/dd_real.h
@@ -286,5 +286,9 @@ QD_API std::istream& operator>>(std::istream &s, dd_real &a);
 #include <qd/dd_inline.h>
 #endif
 
+
+
+QD_API extern bool suppress_error_messages; /** Set to true to suppress error messages. Initialized in dd_real.cpp */
+
 #endif /* _QD_DD_REAL_H */
 

--- a/src/dd_real.cpp
+++ b/src/dd_real.cpp
@@ -39,6 +39,7 @@ using std::setw;
 
 /* This routine is called whenever a fatal error occurs. */
 void dd_real::error(const char *msg) { 
+  if (suppress_error_messages) return;
   if (msg) { cerr << "ERROR " << msg << endl; }
 }
 
@@ -1304,3 +1305,6 @@ dd_real dd_real::debug_rand() {
   }
   return a;
 }
+
+
+bool suppress_error_messages = false;

--- a/src/qd_real.cpp
+++ b/src/qd_real.cpp
@@ -40,6 +40,7 @@ using std::setw;
 using namespace qd;
 
 void qd_real::error(const char *msg) {
+  if (suppress_error_messages) return;
   if (msg) { cerr << "ERROR " << msg << endl; }
 }
 


### PR DESCRIPTION
Explicit printing of error messages can be an issue if the situation which leads to an error happens within a large code base used on computing clusters. It maybe be convenient to handle the problem which leads to a QD error elsewhere on higher level by detecting a NaN result without caring about an exact reason. But the error messages in QD cannot be disabled, even if the error is actually handled, and can cause bloating of logs.

To fix the issue I propose to add a switch which allows the users to manually turn off printing the error messages. By default the switch is off, so the behavior is as before.