### PR TITLE
Fix normalized comparison semantics for dd_real and qd_real

### DIFF
--- a/include/qd/dd_inline.h
+++ b/include/qd/dd_inline.h
@@ -436,99 +436,166 @@ inline dd_real &dd_real::operator=(double a) {
 }
 
 /*********** Equality Comparisons ************/
+namespace qd {
+template <class A, class B>
+inline dd_real dd_comparison_difference(const A &a, const B &b) {
+  return dd_real(a) - dd_real(b);
+}
+
+template <class A, class B>
+inline bool dd_comparison_eq(const A &a, const B &b) {
+  dd_real da(a);
+  dd_real db(b);
+  if (da.isnan() || db.isnan())
+    return false;
+  if (da.isinf() || db.isinf())
+    return da.x[0] == db.x[0];
+  dd_real d = dd_comparison_difference(da, db);
+  return d.is_zero();
+}
+
+template <class A, class B>
+inline bool dd_comparison_lt(const A &a, const B &b) {
+  dd_real da(a);
+  dd_real db(b);
+  if (da.isnan() || db.isnan())
+    return false;
+  if (da.isinf() || db.isinf())
+    return da.x[0] < db.x[0];
+  dd_real d = dd_comparison_difference(da, db);
+  return d.is_negative();
+}
+
+template <class A, class B>
+inline bool dd_comparison_gt(const A &a, const B &b) {
+  dd_real da(a);
+  dd_real db(b);
+  if (da.isnan() || db.isnan())
+    return false;
+  if (da.isinf() || db.isinf())
+    return da.x[0] > db.x[0];
+  dd_real d = dd_comparison_difference(da, db);
+  return d.is_positive();
+}
+
+template <class A, class B>
+inline bool dd_comparison_le(const A &a, const B &b) {
+  dd_real da(a);
+  dd_real db(b);
+  if (da.isnan() || db.isnan())
+    return false;
+  if (da.isinf() || db.isinf())
+    return da.x[0] <= db.x[0];
+  dd_real d = dd_comparison_difference(da, db);
+  return d.is_zero() || d.is_negative();
+}
+
+template <class A, class B>
+inline bool dd_comparison_ge(const A &a, const B &b) {
+  dd_real da(a);
+  dd_real db(b);
+  if (da.isnan() || db.isnan())
+    return false;
+  if (da.isinf() || db.isinf())
+    return da.x[0] >= db.x[0];
+  dd_real d = dd_comparison_difference(da, db);
+  return d.is_zero() || d.is_positive();
+}
+}
+
 /* double-double == double */
 inline bool operator==(const dd_real &a, double b) {
-  return (a.x[0] == b && a.x[1] == 0.0);
+  return qd::dd_comparison_eq(a, b);
 }
 
 /* double-double == double-double */
 inline bool operator==(const dd_real &a, const dd_real &b) {
-  return (a.x[0] == b.x[0] && a.x[1] == b.x[1]);
+  return qd::dd_comparison_eq(a, b);
 }
 
 /* double == double-double */
 inline bool operator==(double a, const dd_real &b) {
-  return (a == b.x[0] && b.x[1] == 0.0);
+  return qd::dd_comparison_eq(a, b);
 }
 
 /*********** Greater-Than Comparisons ************/
 /* double-double > double */
 inline bool operator>(const dd_real &a, double b) {
-  return (a.x[0] > b || (a.x[0] == b && a.x[1] > 0.0));
+  return qd::dd_comparison_gt(a, b);
 }
 
 /* double-double > double-double */
 inline bool operator>(const dd_real &a, const dd_real &b) {
-  return (a.x[0] > b.x[0] || (a.x[0] == b.x[0] && a.x[1] > b.x[1]));
+  return qd::dd_comparison_gt(a, b);
 }
 
 /* double > double-double */
 inline bool operator>(double a, const dd_real &b) {
-  return (a > b.x[0] || (a == b.x[0] && b.x[1] < 0.0));
+  return qd::dd_comparison_gt(a, b);
 }
 
 /*********** Less-Than Comparisons ************/
 /* double-double < double */
 inline bool operator<(const dd_real &a, double b) {
-  return (a.x[0] < b || (a.x[0] == b && a.x[1] < 0.0));
+  return qd::dd_comparison_lt(a, b);
 }
 
 /* double-double < double-double */
 inline bool operator<(const dd_real &a, const dd_real &b) {
-  return (a.x[0] < b.x[0] || (a.x[0] == b.x[0] && a.x[1] < b.x[1]));
+  return qd::dd_comparison_lt(a, b);
 }
 
 /* double < double-double */
 inline bool operator<(double a, const dd_real &b) {
-  return (a < b.x[0] || (a == b.x[0] && b.x[1] > 0.0));
+  return qd::dd_comparison_lt(a, b);
 }
 
 /*********** Greater-Than-Or-Equal-To Comparisons ************/
 /* double-double >= double */
 inline bool operator>=(const dd_real &a, double b) {
-  return (a.x[0] > b || (a.x[0] == b && a.x[1] >= 0.0));
+  return qd::dd_comparison_ge(a, b);
 }
 
 /* double-double >= double-double */
 inline bool operator>=(const dd_real &a, const dd_real &b) {
-  return (a.x[0] > b.x[0] || (a.x[0] == b.x[0] && a.x[1] >= b.x[1]));
+  return qd::dd_comparison_ge(a, b);
 }
 
 /* double >= double-double */
 inline bool operator>=(double a, const dd_real &b) {
-  return (b <= a);
+  return qd::dd_comparison_ge(a, b);
 }
 
 /*********** Less-Than-Or-Equal-To Comparisons ************/
 /* double-double <= double */
 inline bool operator<=(const dd_real &a, double b) {
-  return (a.x[0] < b || (a.x[0] == b && a.x[1] <= 0.0));
+  return qd::dd_comparison_le(a, b);
 }
 
 /* double-double <= double-double */
 inline bool operator<=(const dd_real &a, const dd_real &b) {
-  return (a.x[0] < b.x[0] || (a.x[0] == b.x[0] && a.x[1] <= b.x[1]));
+  return qd::dd_comparison_le(a, b);
 }
 
 /* double <= double-double */
 inline bool operator<=(double a, const dd_real &b) {
-  return (b >= a);
+  return qd::dd_comparison_le(a, b);
 }
 
 /*********** Not-Equal-To Comparisons ************/
 /* double-double != double */
 inline bool operator!=(const dd_real &a, double b) {
-  return (a.x[0] != b || a.x[1] != 0.0);
+  return !(a == b);
 }
 
 /* double-double != double-double */
 inline bool operator!=(const dd_real &a, const dd_real &b) {
-  return (a.x[0] != b.x[0] || a.x[1] != b.x[1]);
+  return !(a == b);
 }
 
 /* double != double-double */
 inline bool operator!=(double a, const dd_real &b) {
-  return (a != b.x[0] || b.x[1] != 0.0);
+  return !(a == b);
 }
 
 /*********** Micellaneous ************/

--- a/include/qd/qd_inline.h
+++ b/include/qd/qd_inline.h
@@ -819,132 +819,179 @@ inline qd_real &qd_real::operator=(const dd_real &a) {
 }
 
 /********** Equality Comparison **********/
+namespace qd {
+template <class A, class B>
+inline qd_real comparison_difference(const A &a, const B &b) {
+  qd_real d = qd_real(a) - qd_real(b);
+  d.renorm();
+  return d;
+}
+
+template <class A, class B>
+inline bool comparison_eq(const A &a, const B &b) {
+  qd_real qa(a);
+  qd_real qb(b);
+  if (qa.isnan() || qb.isnan())
+    return false;
+  if (qa.isinf() || qb.isinf())
+    return qa[0] == qb[0];
+  qd_real d = comparison_difference(qa, qb);
+  return d.is_zero();
+}
+
+template <class A, class B>
+inline bool comparison_lt(const A &a, const B &b) {
+  qd_real qa(a);
+  qd_real qb(b);
+  if (qa.isnan() || qb.isnan())
+    return false;
+  if (qa.isinf() || qb.isinf())
+    return qa[0] < qb[0];
+  qd_real d = comparison_difference(qa, qb);
+  return d.is_negative();
+}
+
+template <class A, class B>
+inline bool comparison_gt(const A &a, const B &b) {
+  qd_real qa(a);
+  qd_real qb(b);
+  if (qa.isnan() || qb.isnan())
+    return false;
+  if (qa.isinf() || qb.isinf())
+    return qa[0] > qb[0];
+  qd_real d = comparison_difference(qa, qb);
+  return d.is_positive();
+}
+
+template <class A, class B>
+inline bool comparison_le(const A &a, const B &b) {
+  qd_real qa(a);
+  qd_real qb(b);
+  if (qa.isnan() || qb.isnan())
+    return false;
+  if (qa.isinf() || qb.isinf())
+    return qa[0] <= qb[0];
+  qd_real d = comparison_difference(qa, qb);
+  return d.is_zero() || d.is_negative();
+}
+
+template <class A, class B>
+inline bool comparison_ge(const A &a, const B &b) {
+  qd_real qa(a);
+  qd_real qb(b);
+  if (qa.isnan() || qb.isnan())
+    return false;
+  if (qa.isinf() || qb.isinf())
+    return qa[0] >= qb[0];
+  qd_real d = comparison_difference(qa, qb);
+  return d.is_zero() || d.is_positive();
+}
+}
+
 inline bool operator==(const qd_real &a, double b) {
-  return (a[0] == b && a[1] == 0.0 && a[2] == 0.0 && a[3] == 0.0);
+  return qd::comparison_eq(a, b);
 }
 
 inline bool operator==(double a, const qd_real &b) {
-  return (b == a);
+  return qd::comparison_eq(a, b);
 }
 
 inline bool operator==(const qd_real &a, const dd_real &b) {
-  return (a[0] == b._hi() && a[1] == b._lo() && 
-          a[2] == 0.0 && a[3] == 0.0);
+  return qd::comparison_eq(a, b);
 }
 
 inline bool operator==(const dd_real &a, const qd_real &b) {
-  return (b == a);
+  return qd::comparison_eq(a, b);
 }
 
 inline bool operator==(const qd_real &a, const qd_real &b) {
-  return (a[0] == b[0] && a[1] == b[1] && 
-          a[2] == b[2] && a[3] == b[3]);
+  return qd::comparison_eq(a, b);
 }
 
 
 /********** Less-Than Comparison ***********/
 inline bool operator<(const qd_real &a, double b) {
-  return (a[0] < b || (a[0] == b && a[1] < 0.0));
+  return qd::comparison_lt(a, b);
 }
 
 inline bool operator<(double a, const qd_real &b) {
-  return (b > a);
+  return qd::comparison_lt(a, b);
 }
 
 inline bool operator<(const qd_real &a, const dd_real &b) {
-  return (a[0] < b._hi() || 
-          (a[0] == b._hi() && (a[1] < b._lo() ||
-                            (a[1] == b._lo() && a[2] < 0.0))));
+  return qd::comparison_lt(a, b);
 }
 
 inline bool operator<(const dd_real &a, const qd_real &b) {
-  return (b > a);
+  return qd::comparison_lt(a, b);
 }
 
 inline bool operator<(const qd_real &a, const qd_real &b) {
-  return (a[0] < b[0] ||
-          (a[0] == b[0] && (a[1] < b[1] ||
-                            (a[1] == b[1] && (a[2] < b[2] ||
-                                              (a[2] == b[2] && a[3] < b[3]))))));
+  return qd::comparison_lt(a, b);
 }
 
 /********** Greater-Than Comparison ***********/
 inline bool operator>(const qd_real &a, double b) {
-  return (a[0] > b || (a[0] == b && a[1] > 0.0));
+  return qd::comparison_gt(a, b);
 }
 
 inline bool operator>(double a, const qd_real &b) {
-  return (b < a);
+  return qd::comparison_gt(a, b);
 }
 
 inline bool operator>(const qd_real &a, const dd_real &b) {
-  return (a[0] > b._hi() || 
-          (a[0] == b._hi() && (a[1] > b._lo() ||
-                            (a[1] == b._lo() && a[2] > 0.0))));
+  return qd::comparison_gt(a, b);
 }
 
 inline bool operator>(const dd_real &a, const qd_real &b) {
-  return (b < a);
+  return qd::comparison_gt(a, b);
 }
 
 inline bool operator>(const qd_real &a, const qd_real &b) {
-  return (a[0] > b[0] ||
-          (a[0] == b[0] && (a[1] > b[1] ||
-                            (a[1] == b[1] && (a[2] > b[2] ||
-                                              (a[2] == b[2] && a[3] > b[3]))))));
+  return qd::comparison_gt(a, b);
 }
 
 
 /********** Less-Than-Or-Equal-To Comparison **********/
 inline bool operator<=(const qd_real &a, double b) {
-  return (a[0] < b || (a[0] == b && a[1] <= 0.0));
+  return qd::comparison_le(a, b);
 }
 
 inline bool operator<=(double a, const qd_real &b) {
-  return (b >= a);
+  return qd::comparison_le(a, b);
 }
 
 inline bool operator<=(const qd_real &a, const dd_real &b) {
-  return (a[0] < b._hi() || 
-          (a[0] == b._hi() && (a[1] < b._lo() || 
-                            (a[1] == b._lo() && a[2] <= 0.0))));
+  return qd::comparison_le(a, b);
 }
 
 inline bool operator<=(const dd_real &a, const qd_real &b) {
-  return (b >= a);
+  return qd::comparison_le(a, b);
 }
 
 inline bool operator<=(const qd_real &a, const qd_real &b) {
-  return (a[0] < b[0] || 
-          (a[0] == b[0] && (a[1] < b[1] ||
-                            (a[1] == b[1] && (a[2] < b[2] ||
-                                              (a[2] == b[2] && a[3] <= b[3]))))));
+  return qd::comparison_le(a, b);
 }
 
 /********** Greater-Than-Or-Equal-To Comparison **********/
 inline bool operator>=(const qd_real &a, double b) {
-  return (a[0] > b || (a[0] == b && a[1] >= 0.0));
+  return qd::comparison_ge(a, b);
 }
 
 inline bool operator>=(double a, const qd_real &b) {
-  return (b <= a);
+  return qd::comparison_ge(a, b);
 }
 
 inline bool operator>=(const qd_real &a, const dd_real &b) {
-  return (a[0] > b._hi() || 
-          (a[0] == b._hi() && (a[1] > b._lo() || 
-                            (a[1] == b._lo() && a[2] >= 0.0))));
+  return qd::comparison_ge(a, b);
 }
 
 inline bool operator>=(const dd_real &a, const qd_real &b) {
-  return (b <= a);
+  return qd::comparison_ge(a, b);
 }
 
 inline bool operator>=(const qd_real &a, const qd_real &b) {
-  return (a[0] > b[0] || 
-          (a[0] == b[0] && (a[1] > b[1] ||
-                            (a[1] == b[1] && (a[2] > b[2] ||
-                                              (a[2] == b[2] && a[3] >= b[3]))))));
+  return qd::comparison_ge(a, b);
 }
 
 

--- a/release/check_16_builds.sh
+++ b/release/check_16_builds.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+set -u
+
+# Matrix test for QD with 16 configure combinations:
+#   ieee_add   = yes/no
+#   sloppy_mul = yes/no
+#   sloppy_div = yes/no
+#   fma        = yes/no  (--enable-fma=gnu -mfma / --disable-fma)
+#
+# Default usage:
+#   bash misc/check_16_builds.sh
+#
+# Optional environment variables:
+#   SRC_DIR=/path/to/QD
+#   BUILD_ROOT=/path/to/build-root
+#   JOBS=8
+#   KEEP_BUILD=1   # keep existing build dirs instead of deleting them
+#
+# Notes:
+# - This script expects an Autotools project with out-of-tree builds.
+# - If the source tree was previously configured in-tree, this script will
+#   try to clean it once before running the matrix.
+
+SRC_DIR="${SRC_DIR:-$(pwd)}"
+BUILD_ROOT="${BUILD_ROOT:-$SRC_DIR/_build_matrix}"
+LOG_DIR="$BUILD_ROOT/logs"
+MAKE_CMD="${MAKE:-make}"
+KEEP_BUILD="${KEEP_BUILD:-0}"
+
+detect_jobs() {
+    if [ -n "${JOBS:-}" ]; then
+        echo "$JOBS"
+        return
+    fi
+    if command -v nproc >/dev/null 2>&1; then
+        nproc
+        return
+    fi
+    if command -v getconf >/dev/null 2>&1; then
+        getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4
+        return
+    fi
+    echo 4
+}
+
+JOBS="$(detect_jobs)"
+
+enable_flag() {
+    key="$1"
+    val="$2"
+    case "$key" in
+        ieee_add)
+            [ "$val" = "yes" ] && echo "--enable-ieee-add" || echo "--disable-ieee-add"
+            ;;
+        sloppy_mul)
+            [ "$val" = "yes" ] && echo "--enable-sloppy-mul" || echo "--disable-sloppy-mul"
+            ;;
+        sloppy_div)
+            [ "$val" = "yes" ] && echo "--enable-sloppy-div" || echo "--disable-sloppy-div"
+            ;;
+        fma)
+            [ "$val" = "yes" ] && echo "--with-arch=x86-64-v3" || echo "--disable-fma"
+            ;;
+        *)
+            echo "unknown configure flag key: $key" >&2
+            exit 2
+            ;;
+    esac
+}
+
+prepare_source_tree() {
+    echo "=== Preparing source tree ==="
+    echo "SRC_DIR: $SRC_DIR"
+
+    if [ ! -d "$SRC_DIR" ]; then
+        echo "ERROR: source directory does not exist: $SRC_DIR" >&2
+        exit 2
+    fi
+
+    if [ ! -x "$SRC_DIR/configure" ]; then
+        echo "ERROR: configure script not found or not executable: $SRC_DIR/configure" >&2
+        exit 2
+    fi
+
+    # If the source tree was configured in-tree before, out-of-tree configure
+    # will fail. Clean it once here.
+    if [ -f "$SRC_DIR/config.status" ]; then
+        echo "Source tree appears to be configured in-tree."
+        echo "Running one-time cleanup in source tree..."
+
+        (
+            set -e
+            cd "$SRC_DIR"
+
+            if [ -f Makefile ]; then
+                "$MAKE_CMD" distclean || true
+            fi
+
+            # In some broken states, distclean may not remove these.
+            rm -f config.status config.cache config.log
+        ) || {
+            echo "ERROR: failed to clean source tree: $SRC_DIR" >&2
+            exit 2
+        }
+    fi
+
+    # If config.status still exists, abort clearly.
+    if [ -f "$SRC_DIR/config.status" ]; then
+        echo "ERROR: source tree is still configured after cleanup." >&2
+        echo "Please inspect and clean manually:" >&2
+        echo "  cd \"$SRC_DIR\" && make distclean" >&2
+        exit 2
+    fi
+
+    echo "Source tree is ready for out-of-tree builds."
+    echo
+}
+
+mkdir -p "$BUILD_ROOT" "$LOG_DIR"
+
+SUMMARY_OK="$BUILD_ROOT/summary.ok"
+SUMMARY_NG="$BUILD_ROOT/summary.ng"
+SUMMARY_TSV="$BUILD_ROOT/summary.tsv"
+: > "$SUMMARY_OK"
+: > "$SUMMARY_NG"
+printf "tag\tresult\tlog\n" > "$SUMMARY_TSV"
+
+fail_count=0
+
+run_one() {
+    ieee_add="$1"
+    sloppy_mul="$2"
+    sloppy_div="$3"
+    fma="$4"
+
+    tag="ieee_add-${ieee_add}__sloppy_mul-${sloppy_mul}__sloppy_div-${sloppy_div}__fma-${fma}"
+    build_dir="$BUILD_ROOT/$tag"
+    log_file="$LOG_DIR/$tag.log"
+
+    if [ "$KEEP_BUILD" != "1" ]; then
+        rm -rf "$build_dir"
+    fi
+    mkdir -p "$build_dir"
+
+    echo "=== $tag ==="
+    echo "build_dir: $build_dir"
+    echo "log_file : $log_file"
+
+    # CXXFLAGS: add -mfma only when fma=yes
+    if [ "$fma" = "yes" ]; then
+        cxxflags="-mfma"
+    else
+        cxxflags=""
+    fi
+
+    (
+        set -e
+        cd "$build_dir"
+
+        "$SRC_DIR/configure" \
+            --srcdir="$SRC_DIR" \
+            "$(enable_flag ieee_add "$ieee_add")" \
+            "$(enable_flag sloppy_mul "$sloppy_mul")" \
+            "$(enable_flag sloppy_div "$sloppy_div")" \
+            "$(enable_flag fma "$fma")" \
+            CXXFLAGS="$cxxflags -O2"
+
+        "$MAKE_CMD" -j"$JOBS"
+        "$MAKE_CMD" check
+        "$MAKE_CMD" -C tests huge
+        ./tests/huge
+    ) >"$log_file" 2>&1
+
+    rc=$?
+    if [ "$rc" -eq 0 ]; then
+        echo "PASS $tag"
+        echo "$tag" >> "$SUMMARY_OK"
+        echo "--- log: $log_file ---"
+        sed -n '/Testing dd_real \.\.\./,$p' "$log_file" || true
+        printf "%s\tPASS\t%s\n" "$tag" "$log_file" >> "$SUMMARY_TSV"
+    else
+        echo "FAIL $tag"
+        echo "$tag" >> "$SUMMARY_NG"
+        printf "%s\tFAIL\t%s\n" "$tag" "$log_file" >> "$SUMMARY_TSV"
+        echo "--- log: $log_file ---"
+        sed -n '/Testing dd_real \.\.\./,$p' "$log_file" || true
+        echo "---------------------------"
+        fail_count=$((fail_count + 1))
+    fi
+    echo
+}
+
+run_default() {
+    tag="default"
+    build_dir="$BUILD_ROOT/$tag"
+    log_file="$LOG_DIR/$tag.log"
+
+    if [ "$KEEP_BUILD" != "1" ]; then
+        rm -rf "$build_dir"
+    fi
+    mkdir -p "$build_dir"
+
+    echo "=== $tag ==="
+    echo "build_dir: $build_dir"
+    echo "log_file : $log_file"
+
+    (
+        set -e
+        cd "$build_dir"
+
+        "$SRC_DIR/configure" --srcdir="$SRC_DIR"
+
+        "$MAKE_CMD" -j"$JOBS"
+        "$MAKE_CMD" check
+        "$MAKE_CMD" -C tests huge
+        ./tests/huge
+    ) >"$log_file" 2>&1
+
+    rc=$?
+    if [ "$rc" -eq 0 ]; then
+        echo "PASS $tag"
+        echo "$tag" >> "$SUMMARY_OK"
+        echo "--- log: $log_file ---"
+        sed -n '/Testing dd_real \.\.\.$/,$p' "$log_file" || true
+        printf "%s\tPASS\t%s\n" "$tag" "$log_file" >> "$SUMMARY_TSV"
+    else
+        echo "FAIL $tag"
+        echo "$tag" >> "$SUMMARY_NG"
+        printf "%s\tFAIL\t%s\n" "$tag" "$log_file" >> "$SUMMARY_TSV"
+        echo "--- log: $log_file ---"
+        sed -n '/Testing dd_real \.\.\.$/,$p' "$log_file" || true
+        echo "---------------------------"
+        fail_count=$((fail_count + 1))
+    fi
+    echo
+}
+
+prepare_source_tree
+
+run_default
+
+for ieee_add in no yes; do
+    for sloppy_mul in no yes; do
+        for sloppy_div in no yes; do
+            for fma in no yes; do
+                run_one "$ieee_add" "$sloppy_mul" "$sloppy_div" "$fma"
+            done
+        done
+    done
+done
+
+echo "========================================"
+echo "Finished."
+echo "PASS list : $SUMMARY_OK"
+echo "FAIL list : $SUMMARY_NG"
+echo "TSV       : $SUMMARY_TSV"
+echo "Logs      : $LOG_DIR"
+echo "Failures  : $fail_count"
+
+if [ "$fail_count" -ne 0 ]; then
+    exit 1
+fi
+exit 0

--- a/tests/qd_test.cpp
+++ b/tests/qd_test.cpp
@@ -425,6 +425,67 @@ bool TestSuite<T>::test8() {
   return (delta < 4.0 * T::_eps);
 }
 
+bool test_qd_real_comparison() {
+  cout << endl;
+  cout << "Test 9.  (qd_real comparison normalization)." << endl;
+
+  qd_real a(1.0, 0.5, 0.0, 0.0);
+  qd_real b(1.5);
+  qd_real diff = a - b;
+  diff.renorm();
+
+  bool pass = diff.is_zero();
+  pass &= (a == b);
+  pass &= !(a != b);
+  pass &= !(a < b);
+  pass &= !(a > b);
+  pass &= (a <= b);
+  pass &= (a >= b);
+
+  pass &= (a == 1.5);
+  pass &= (1.5 == a);
+  pass &= (a == dd_real(1.5));
+  pass &= (dd_real(1.5) == a);
+
+  if (flag_verbose) {
+    cout << "a = [" << a[0] << ", " << a[1] << ", "
+         << a[2] << ", " << a[3] << "]" << endl;
+    cout << "b = " << b << endl;
+    cout << "renormalized diff is zero: " << diff.is_zero() << endl;
+  }
+
+  return pass;
+}
+
+bool test_dd_real_comparison() {
+  cout << endl;
+  cout << "Test 9.  (dd_real comparison normalization)." << endl;
+
+  double lo = std::ldexp(1.0, -53);
+  dd_real a(1.0 - lo, lo);
+  dd_real b(1.0);
+  dd_real diff = a - b;
+
+  bool pass = diff.is_zero();
+  pass &= (a == b);
+  pass &= !(a != b);
+  pass &= !(a < b);
+  pass &= !(a > b);
+  pass &= (a <= b);
+  pass &= (a >= b);
+
+  pass &= (a == 1.0);
+  pass &= (1.0 == a);
+
+  if (flag_verbose) {
+    cout << "a = [" << a._hi() << ", " << a._lo() << "]" << endl;
+    cout << "b = " << b << endl;
+    cout << "diff is zero: " << diff.is_zero() << endl;
+  }
+
+  return pass;
+}
+
 template <class T>
 bool TestSuite<T>::testall() {
   bool pass = true;
@@ -494,6 +555,7 @@ int main(int argc, char *argv[]) {
     if (flag_verbose)
       cout << "sizeof(dd_real) = " << sizeof(dd_real) << endl;
     pass &= dd_test.testall();
+    pass &= print_result(test_dd_real_comparison());
   }
 
   if (flag_test_qd) {
@@ -504,9 +566,9 @@ int main(int argc, char *argv[]) {
     if (flag_verbose)
       cout << "sizeof(qd_real) = " << sizeof(qd_real) << endl;
     pass &= qd_test.testall();
+    pass &= print_result(test_qd_real_comparison());
   }
   
   fpu_fix_end(&old_cw);
   return (pass ? 0 : 1);
 }
-


### PR DESCRIPTION
Fix comparison operators for `dd_real` and `qd_real` so values with different
  component layouts but the same exact normalized value compare equal.

  Previously, equality compared internal components directly. For example:

  ```cpp
  qd_real a(1.0, 0.5, 0.0, 0.0);
  qd_real b(1.5);

  These represent the same value, but the old implementation compared:

  a[0] == b[0]  // 1.0 == 1.5
  a[1] == b[1]  // 0.5 == 0.0

  so a == b returned false.

  The same issue can happen for dd_real:

  double lo = std::ldexp(1.0, -53);
  dd_real a(1.0 - lo, lo);
  dd_real b(1.0);

  Here a - b is exactly zero after normalization, but direct component comparison
  can still report the values as unequal.

  This PR changes comparisons to use exact normalized-difference semantics rather
  than raw component equality or tolerance-based equality.