### PR TITLE
Fix O(eps^3) cross-term accumulation bug in qd_real * dd_real

### DIFF
--- a/include/qd/qd_inline.h
+++ b/include/qd/qd_inline.h
@@ -545,7 +545,7 @@ inline qd_real operator*(const qd_real &a, const dd_real &b) {
   s2 = t0 + t1 + p4;
   p2 = s0;
 
-  p3 = a[2] * b._hi() + a[3] * b._lo() + q3 + q4;
+  p3 = a[2] * b._lo() + a[3] * b._hi() + q3 + q4;
   qd::three_sum2(p3, q0, s1);
   p4 = q0 + s2;
 


### PR DESCRIPTION
## Bug Fix: Swapped `b._hi()`/`b._lo()` in `operator*(qd_real, dd_real)` cross-term accumulation

### Description

This PR fixes a bug in the $\mathcal{O}(\text{eps}^3)$ cross-term accumulation during the multiplication of a `qd_real` by a `dd_real`.

In `operator*(const qd_real &a, const dd_real &b)` in `qd_inline.h`, the comment block (lines 517-524) documents the intended product structure:

```
/* a0 * b0                        0
        a0 * b1                   1
        a1 * b0                   2
             a1 * b1              3
             a2 * b0              4
                  a2 * b1         5
                  a3 * b0         6
                       a3 * b1    7 */
```

The function computes exact `two_prod` decompositions for the first five products:

```cpp
p0 = qd::two_prod(a[0], b._hi(), q0);   // a0*b0 = p0 + q0
p1 = qd::two_prod(a[0], b._lo(), q1);   // a0*b1 = p1 + q1
p2 = qd::two_prod(a[1], b._hi(), q2);   // a1*b0 = p2 + q2
p3 = qd::two_prod(a[1], b._lo(), q3);   // a1*b1 = p3 + q3
p4 = qd::two_prod(a[2], b._hi(), q4);   // a2*b0 = p4 + q4
```

After the `three_sum` / Five-Three-Sum accumulation (lines 537-546), all of `p0` through `p4` and `q0` through `q2` have been fully consumed into the result components `p0`, `p1`, `p2` and the residuals `q0`, `s1`, `s2`.

The current line 548 then accumulates the $\mathcal{O}(\text{eps}^3)$ terms:

```cpp
p3 = a[2] * b._hi() + a[3] * b._lo() + q3 + q4;   // <-- BUG
```

This is incorrect:
- **`a[2] * b._hi()`** is `fl(a[2] * b[0])`, which approximates the *already fully accumulated* product `a2*b0 = p4 + q4`. Both `p4` (consumed in the Five-Three-Sum at line 539) and `q4` (added on this same line) have already entered the accumulation. This term **double-counts** the leading part of the `a2*b0` product.
- **`a[3] * b._lo()`** is `fl(a[3] * b[1])`, an $\mathcal{O}(\text{eps}^4)$ term (row 7 in the diagram), negligible at this accumulation stage.
- The actual $\mathcal{O}(\text{eps}^3)$ cross-products, **`a[2] * b[1]`** (row 5) and **`a[3] * b[0]`** (row 6), are **completely missing**.

### Corrected line

```cpp
p3 = a[2] * b._lo() + a[3] * b._hi() + q3 + q4;
```

This correctly accumulates:
- `a[2] * b._lo()` = `fl(a[2] * b[1])`, the $\mathcal{O}(\text{eps}^3)$ cross-product from row 5
- `a[3] * b._hi()` = `fl(a[3] * b[0])`, the $\mathcal{O}(\text{eps}^3)$ cross-product from row 6
- `q3`, `q4`: the remainders from the `two_prod` decompositions of `a1*b1` and `a2*b0`

### Supporting evidence: comparison with `sloppy_mul`

The analogous $\mathcal{O}(\text{eps}^3)$ accumulation in `qd_real::sloppy_mul(qd_real, qd_real)` (line 596) correctly uses the cross-terms:

```cpp
s1 += a[0]*b[3] + a[1]*b[2] + a[2]*b[1] + a[3]*b[0] + q0 + q3 + q4 + q5;
```

For `qd * dd` where `b` has only two components (`b[0] = b._hi()`, `b[1] = b._lo()`), the corresponding $\mathcal{O}(\text{eps}^3)$ cross-terms are `a[2]*b[1]` and `a[3]*b[0]`, i.e. `a[2]*b._lo()` and `a[3]*b._hi()`, matching the fix.

### Provenance

This bug is present in the original LBNL QD library by Hida, Li, and Bailey, and has been inherited by all known forks (scibuilder/QD, GFTwrt/QD, BL-highprecision/QD). It likely survived because:
1. The `qd * dd` operator is less commonly exercised than `qd * qd` or `qd * double`.
2. The effect is confined to the 3rd-4th components of the quad-double result, costing roughly one double's worth of precision (about 16 decimal digits) out of the approximately 64 available, making it difficult to detect in casual testing.
